### PR TITLE
Upgrade to Spring Boot 3.3.7 and Cloud 2023.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.3.7</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.starkandwayne</groupId>
@@ -16,7 +16,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<spring-cloud-services.version>3.4.0</spring-cloud-services.version>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
+		<spring-cloud.version>2023.0.4</spring-cloud.version>
 	</properties>
 	<dependencies>
 


### PR DESCRIPTION
- Updated parent POM to Spring Boot 3.3.7
- Bumped spring-cloud.version to 2023.0.4 (Leyton SR4)
- Enables use of spring-cloud-starter-* components at versions 4.1.4/4.1.5
- Addresses security issues in earlier Spring Cloud versions
- Ensures compatibility with Spring Boot 3.3.x ecosystem